### PR TITLE
Add OSQP as an alternative solver in the contacts computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,40 @@ In the simulator the ground is assumed to be flat and the contact forces are com
 
 ## :hammer: Dependencies
 
-- [Matlab/Simulink 2020a](https://it.mathworks.com/products/matlab.html)
+- [Matlab/Simulink 2019b](https://it.mathworks.com/products/matlab.html)
 - [iDynTree](https://github.com/robotology/idyntree)
+- [OSQP](https://github.com/oxfordcontrol/osqp.git)
+- [osqp-matlab](https://github.com/oxfordcontrol/osqp-matlab) (the OSQP MATLAB bindings).
 - [icub-models](https://github.com/robotology/icub-models) to access iCub models.
 
-It is to suggest to install `iDynTree`, `icub-models` using the [robotology-superbuild](https://github.com/robotology/robotology-superbuild).
+It is recommended to install `iDynTree`, `icub-models` and `OSQP` using the [robotology-superbuild](https://github.com/robotology/robotology-superbuild):
+- `icub-models`: set the profile option `ROBOTOLOGY_ENABLE_CORE`.
+- `iDynTree` and `OSQP`: set the profile option `ROBOTOLOGY_ENABLE_DYNAMICS`.
+
+## :floppy_disk: Installing the OSQP MATLAB bindings
+
+- `OSQP` library:<br/>
+    It is recommended to install the `OSQP` library through the [robotology-superbuild](https://github.com/robotology/robotology-superbuild), by setting the profile `ROBOTOLOGY_ENABLE_DYNAMICS`in the superbuild cmake options. The `OSQP` library will then be installed along with `iDynTree` as an external dependency.
+
+- `OSQP` MATLAB bindings (https://osqp.org/docs/get_started/matlab.html):<br/>
+    - Clone the repository [osqp-matlab](https://github.com/oxfordcontrol/osqp-matlab) (the OSQP MATLAB bindings) in the location of your choice.
+    ```
+    cd <some-path>
+    !git clone --recurse-submodules https://github.com/oxfordcontrol/osqp-matlab
+    cd osqp-matlab
+    make_osqp
+    ```
+    - Set accordingly the environment variable `OSQP_MATLAB_PATH` in the bash profile (on Linux: /home/<user>/.bashrc, on MacOS: /home/\<user\>/.bash_profile):
+    ```
+    export OSQP_MATLAB_PATH=<some-path>/osqp-matlab
+    ```
+    - The option `Config.USE_OSQP` in the main [init](https://github.com/dic-iit/matlab-whole-body-simulators/blob/devel/init.m) file must be set to `true` (default value), otherwise the native MATLAB solver `quadprog` is used instead.
+    
+    For your information, you can find further information on the OSQP library setup and use of the MATLAB interface (bindings) in https://osqp.org/docs:
+    
+    https://osqp.org/docs/index.html<br/>
+    https://osqp.org/docs/get_started/matlab.html<br/>
+    https://osqp.org/docs/interfaces/matlab.html#matlab-interface
 
 ## :runner: How to use the simulator
 

--- a/init.m
+++ b/init.m
@@ -35,7 +35,7 @@ Config.simulationTime = inf;
 Config.GRAVITY_ACC = [0,0,-9.81];
 Config.tStep = 0.001;
 
-% Use qpOASES instead of quadprog, typically in the case where the optimization toolbox is not
+% Use OSQP instead of quadprog, typically in the case where the optimization toolbox is not
 % available.
 Config.USE_OSQP = true;
 

--- a/init.m
+++ b/init.m
@@ -13,6 +13,7 @@
 %  */
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 clear variables
+clear functions
 close all
 clc
 
@@ -34,6 +35,10 @@ Config.simulationTime = inf;
 Config.GRAVITY_ACC = [0,0,-9.81];
 Config.tStep = 0.001;
 
+% Use qpOASES instead of quadprog, typically in the case where the optimization toolbox is not
+% available.
+Config.USE_OSQP = true;
+
 % Do you want to enable the Visualizer?
 confVisualizer.visualizeRobot = true;
 
@@ -47,4 +52,5 @@ run(strcat('app/robots/', robotName, '/initVisualizer.m'));
 %% Init simulator core physics paramaters
 physics_config.GRAVITY_ACC = Config.GRAVITY_ACC;
 physics_config.TIME_STEP = Config.tStep;
+physics_config.USE_OSQP = Config.USE_OSQP;
 robot_config.SIMULATE_MOTOR_REFLECTED_INERTIA = Config.SIMULATE_MOTOR_REFLECTED_INERTIA;

--- a/lib/+wbs/@Contacts/Contacts.m
+++ b/lib/+wbs/@Contacts/Contacts.m
@@ -218,8 +218,9 @@ classdef Contacts < handle
             if obj.useOSQP
                 if firstSolverIter
                     % Setup workspace and change alpha parameter
+                    obj.osqpProb = osqp;
                     obj.osqpProb.setup(sparse(H), free_contact_acceleration, sparse([obj.A;obj.Aeq]), [obj.Ax_Lb;obj.beq], [obj.Ax_Ub;obj.beq], 'alpha', 1);
-                    firstSolverIter = false;
+                    firstSolverIter = true;
                 else
                     % Update the problem
                     obj.osqpProb.update('Px', nonzeros(triu(sparse(H))), 'q', free_contact_acceleration, 'Ax', sparse([obj.A;obj.Aeq]));

--- a/lib/+wbs/@Contacts/Contacts.m
+++ b/lib/+wbs/@Contacts/Contacts.m
@@ -212,6 +212,7 @@ classdef Contacts < handle
             
             for i = 1:obj.num_vertices * 2
                 obj.Aeq(i, i * 3) = contact_point(i) > 0;
+%                 obj.Aeq(i,i*3-2:i*3) = contact_point(i) > 0;
             end
             
             if obj.useOSQP
@@ -221,7 +222,7 @@ classdef Contacts < handle
                     firstSolverIter = false;
                 else
                     % Update the problem
-                    obj.osqpProb.update('Px', sparse(triu(H)), 'q', free_contact_acceleration, 'Ax', sparse(triu([obj.A;obj.Aeq])));
+                    obj.osqpProb.update('Px', nonzeros(triu(sparse(H))), 'q', free_contact_acceleration, 'Ax', sparse([obj.A;obj.Aeq]));
                 end
                 % Solve problem
                 res = obj.osqpProb.solve();

--- a/lib/RobotDynamicsWithContacts/+robotDynWC/step_block.m
+++ b/lib/RobotDynamicsWithContacts/+robotDynWC/step_block.m
@@ -21,7 +21,7 @@ classdef step_block < matlab.System & matlab.system.mixin.Propagates
 
         function setupImpl(obj)
             obj.robot = wbs.Robot(obj.robot_config,obj.physics_config.GRAVITY_ACC);
-            obj.contacts = wbs.Contacts(obj.contact_config.foot_print, obj.robot, obj.contact_config.friction_coefficient);
+            obj.contacts = wbs.Contacts(obj.contact_config.foot_print, obj.robot, obj.contact_config.friction_coefficient,obj.physics_config.USE_OSQP);
             obj.state = wbs.State(obj.physics_config.TIME_STEP);
             obj.state.set(obj.robot_config.initialConditions.w_H_b, obj.robot_config.initialConditions.s, ...
                 obj.robot_config.initialConditions.base_pose_dot, obj.robot_config.initialConditions.s_dot);

--- a/lib/RobotDynamicsWithContacts/loadRobotDynamicsWithContactsCB.m
+++ b/lib/RobotDynamicsWithContacts/loadRobotDynamicsWithContactsCB.m
@@ -1,3 +1,12 @@
 % Add path to local source code, and parent folder for the making the dependencies classes package
 % visible to MATLAB path.
 addpath(strcat(fileparts(mfilename('fullpath')),'/..'));
+
+% set paths to the osqp-matlab library
+osqp_libraryPath=getenv('OSQP_MATLAB_PATH');
+if exist(osqp_libraryPath, 'dir')==7
+    addpath(genpath(osqp_libraryPath));
+    disp('Added osqp-matlab library');
+else
+    error([osqp_libraryPath,': Path directory non existent!']);
+end


### PR DESCRIPTION
The initial idea was to replace quadprog with qpOASES, but since it will soon be deprecated from the superbuild (refer to [this comment](https://github.com/dic-iit/matlab-whole-body-simulators/pull/10#issuecomment-734158418), we went for OSQP, which actually can be directly called from MATLAB code, i.e. from the class method `Contacts.compute_unilateral_linear_contact`.

The changes are:
- Add option to select OSQP instead of quadprog
- In `prepare_optimization_matrix()`, replaced single boundary `b` by
  double boundary `AxUb` and `AxLb`, and created the OSQP problem object.
- Implemented in `compute_unilateral_linear_contact()` the setup(), update()
  and solve() steps for the OSQP solver.
- Setting the environment variable `OSQP_MATLAB_PATH` is now required for
  finding the OSQP library (https://github.com/oxfordcontrol/osqp-matlab).

### References
https://osqp.org/docs/index.html
https://osqp.org/docs/get_started/matlab.html
https://osqp.org/docs/interfaces/matlab.html#matlab-interface